### PR TITLE
Fix new website's header covering sucess messages

### DIFF
--- a/js/donate_form.js
+++ b/js/donate_form.js
@@ -215,7 +215,7 @@ sdf.validation = (function($) {
 		}
 		
 		if(spark.livemode) {
-			$(window).scrollTop($(el).focus().position().top);
+			$(window).scrollTop($(el).focus().position().top - $('.c-header').height() - 20);
 		}
 	}
 
@@ -269,9 +269,7 @@ sdf.validation = (function($) {
 				+ msg
 			+ '</p>');
 		
-		if(spark.livemode) {
-			alert_el.scrollIntoView();	
-		}
+		self.goto_element($(alert_el));
 	} 
 
 	self.stripe_response_handler = function(status, response) {


### PR DESCRIPTION
On new website there is 65/80px header that is fixed. When scrolling to alert element it is covering first messages. I have added correction for scroll location.